### PR TITLE
Calling new Client() throws Compile Error: "Declaration must be compatible"

### DIFF
--- a/src/Transport/Client.php
+++ b/src/Transport/Client.php
@@ -116,7 +116,7 @@ class Client implements HttpClient
     /**
      * (@inheritdoc}
      */
-    public function sendRequest(RequestInterface $request)
+    public function sendRequest(RequestInterface $request) : ResponseInterface
     {
         if ($this->username || $this->password) {
             switch ($this->authType) {

--- a/src/Transport/Client.php
+++ b/src/Transport/Client.php
@@ -12,6 +12,7 @@ use Http\Client\HttpClient;
 use Http\Client\Socket\Client as SocketHttpClient;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Smalot\Cups\CupsException;
 
 /**


### PR DESCRIPTION
Strict mode requires Client::sendRequest(RequestInterface $request) to return a ResponseInterface but the return type is not declared.

Specific error:
`{"error":{"code":500,"message":"Internal Server Error","exception":[{"message":"Compile Error: Declaration of Smalot\\Cups\\Transport\\Client::sendRequest(Psr\\Http\\Message\\RequestInterface $request) must be compatible with Psr\\Http\\Client\\ClientInterface::sendRequest(Psr\\Http\\Message\\RequestInterface $request): 
`